### PR TITLE
All icon sizes, more comprehensive appdata, desktop fix

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -4,11 +4,18 @@
   <name>Riot</name>
   <project_license>GPL-3.0</project_license>
   <developer_name>Vector Creations Ltd</developer_name>
-  <summary>A glossy Matrix collaboration client for the web</summary>
+  <summary>Create, share, communicate, chat and call securely, and bridge to other apps</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://about.riot.im/</url>
   <description>
-    <p>Riot (formerly known as Vector) is a Matrix web client built using the Matrix React SDK</p>
+    <p>More than group chat: communication</p>
+    <ul>
+      <li>Communicate with your team and out of network colleagues more efficiently: use dedicated rooms which persist information from their creation and forever.</li>
+      <li>Forget group emails: join or create rooms per topic, per team, per event… Decide the level of transparency you want to provide across the organisation or project.</li>
+      <li>Cut through the noise by creating notifications that are customised by you and for you.</li>
+      <li>Grab the attention of your colleague by calling out their name and don’t miss a thing with keyword alerts.</li>
+      <li>Deploy bots for fun or practical use with our integrations store.</li>
+    </ul>
   </description>
   <screenshots>
     <screenshot>
@@ -22,5 +29,34 @@
     <release version="0.13.4" date="2018-01-03"/>
     <release version="0.13.0" date="2017-11-15"/>
   </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
   <update_contact>vrutkovs@redhat.com</update_contact>
 </component>

--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -3,4 +3,4 @@ Type=Application
 Name=Riot
 Icon=im.riot.Riot
 Exec=/app/bin/riot
-Categories=Network;InstantMessaging;Chat;VideoConference
+Categories=Network;InstantMessaging;Chat;VideoConference;

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -6,6 +6,7 @@
     "runtime-version": "1.6",
     "sdk": "org.freedesktop.Sdk",
     "command": "riot",
+    "rename-icon": "riot-web",
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
@@ -27,10 +28,10 @@
                 "rm -f riot-web_*.deb",
                 "tar xf data.tar.xz",
                 "cp -r opt/* /app",
+                "cp -r usr/share/icons/* /app/share/icons",
                 "chmod -R a-s,go+rX,go-w /app/Riot",
                 "install riot.sh /app/bin/riot",
                 "install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop",
-                "install -Dm644 /app/Riot/resources/app/img/riot.png /app/share/icons/hicolor/96x96/apps/im.riot.Riot.png",
                 "install -Dm644 im.riot.Riot.appdata.xml /app/share/appdata/im.riot.Riot.appdata.xml"
             ],
             "sources": [


### PR DESCRIPTION
fix #5 by using all the icons the app ships in /usr.

Fixes a validation error in the desktop file by adding a trailing semicolon

Adds OARS and a longer better description to the appdata