### PR TITLE
Update to 0.13.5

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -26,6 +26,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.13.5" date="2018-02-09"/>
     <release version="0.13.4" date="2018-01-03"/>
     <release version="0.13.0" date="2017-11-15"/>
   </releases>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -39,8 +39,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.13.4_amd64.deb",
-                    "sha256": "d06f1c255e50504828820a0f46db1ce2d4cebd179998210987dba38ddf9fac71"
+                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.13.5_amd64.deb",
+                    "sha256": "cf8c20a603e4a9ff7131bd5b3c94b645409dbfcdea3de17cf552b2af49ca3449"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Security fix, see
https://matrix.org/blog/2018/02/09/security-update-riotweb-0-13-5-released-fixing-xss-vulnerability/

Signed-off-by: Nicholas Sielicki <sielicki@yandex.com>

# **IMPORTANT: This PR is untested/unbuilt.**
