### PR TITLE
Update to use the 18.08 runtime

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -1,9 +1,9 @@
 {
     "app-id": "im.riot.Riot",
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
+    "base-version": "18.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "riot",
     "rename-icon": "riot-web",

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -39,8 +39,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.17.6_amd64.deb",
-                    "sha256": "4eaead15ab27fcdf35a19714488fd58464306a23e67472b96ae7fc8c5b175ab5"
+                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.17.8_amd64.deb",
+                    "sha256": "aeb37398a5cdc72042d9c4c1fcb8c280ee06eb1e2445f16b29014dc887f5be9b"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
The 1.6 freedesktop runtime is heading towards end of life, and will stop receiving updates in the foreseeable future. This uses the new freedesktop-sdk 18.08 runtime, which is maintained. 

This branch is well tested, as I have personally used it for somewhere around 4 months without issue.