### PR TITLE
Update to 0.17.8

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -26,6 +26,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.17.8" date="2018-12-10"/>
     <release version="0.17.6" date="2018-11-19"/>
     <release version="0.17.3" date="2018-10-29"/>
     <release version="0.17.0" date="2018-10-16"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -39,8 +39,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.17.6_amd64.deb",
-                    "sha256": "4eaead15ab27fcdf35a19714488fd58464306a23e67472b96ae7fc8c5b175ab5"
+                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_0.17.8_amd64.deb",
+                    "sha256": "aeb37398a5cdc72042d9c4c1fcb8c280ee06eb1e2445f16b29014dc887f5be9b"
                 },
                 {
                     "type": "script",
@@ -59,8 +59,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/vector-im/riot-web/releases/download/v0.17.6/riot-v0.17.6.tar.gz",
-                    "sha256": "b5dd88900f9f3b9d4d43a3cc329a0ac8f3ef8ec785c99ce057b5b394017668f8"
+                    "url": "https://github.com/vector-im/riot-web/releases/download/v0.17.8/riot-v0.17.8.tar.gz",
+                    "sha256": "7f75be6ee5cc5f398695f31fc05ef22fe5b0255ad9a94341f3f4037cc0802018"
                 }
             ]
         }


### PR DESCRIPTION
Riot version 0.17.6 is outdated by nearly two months. This PR will get the Riot Flatpak up to the latest version.