### PR TITLE
Add new screenshots from 1.0 blog post

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -19,10 +19,13 @@
   </description>
   <screenshots>
     <screenshot>
-      <image type="source">https://about.riot.im/wp-content/uploads/2017/05/Screen-Shot-2017-05-04-at-10.39.44.png</image>
+      <image type="source">https://cdn-images-1.medium.com/max/1600/1*HW0bNUALtn1refBjK25dXw.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://about.riot.im/wp-content/uploads/2016/12/Screen-Shot-2017-05-04-at-10.42.08.jpg</image>
+      <image type="source">https://cdn-images-1.medium.com/max/1600/1*dsciAZ4PifHfaTgqWsahpQ.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://cdn-images-1.medium.com/max/1600/1*bilpNcjPIpGfMMa0QvTArg.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
Since Riot 1.0 there is a redesign of Riot, that should be represented
in its screenshots.

This patch replaces the old screenshots with new ones from the 1.0 blog
post.

Fixes #35 