### PR TITLE
 Update to Riot version 1.0.5 

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -29,7 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.0.4" date="2019-03-11"/>
+    <release version="1.0.4" date="2019-03-19"/>
     <release version="1.0.3" date="2019-03-11"/>
     <release version="1.0.1" date="2019-02-15"/>
     <release version="0.17.9" date="2019-01-22"/>

--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.0.5" date="2019-03-21"/>
     <release version="1.0.4" date="2019-03-19"/>
     <release version="1.0.3" date="2019-03-11"/>
     <release version="1.0.1" date="2019-02-15"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -40,8 +40,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_1.0.4_amd64.deb",
-                    "sha256": "f5a1b24f176467f7a4d0551c198de49f40f506a769f407a3ecdff6857bce94eb"
+                    "url": "https://riot.im/packages/debian/pool/main/r/riot-web/riot-web_1.0.5_amd64.deb",
+                    "sha256": "27cb9ac2faa22b6647c699ba99160e35e62575748e9fe4930f4b84fe07a136d1"
                 },
                 {
                     "type": "script",
@@ -60,8 +60,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.0.4/riot-v1.0.4.tar.gz",
-                    "sha256": "e3586ae64cdfefc5b518833c2b33f1482280180f2e97eb3244ad5a57cb386dec"
+                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.0.5/riot-v1.0.5.tar.gz",
+                    "sha256": "718a5326d2e9c4965942db6a312507514a352b4cd02d6fb5f204b10bb86d1354"
                 }
             ]
         }


### PR DESCRIPTION
There was a hotfix released today: https://github.com/vector-im/riot-web/releases/tag/v1.0.5