### PR TITLE
add --talk-name=org.freedesktop.portal.Fcitx

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -17,6 +17,7 @@
         "--device=all",
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.freedesktop.secrets",
         "--filesystem=xdg-run/keyring"
     ],


### PR DESCRIPTION
This is required for Fcitx users for characters such as backtick.

Ref: flatpak/flatpak#2031