### PR TITLE
Add org.kde.StatusNotifierWatcher permission

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -19,6 +19,7 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.freedesktop.secrets",
+        "--talk-name=org.kde.StatusNotifierWatcher",
         "--filesystem=xdg-run/keyring"
     ],
     "modules": [


### PR DESCRIPTION
This permission is used by KDE as well as some Gnome extension to
provide tray icons and app indicators. In case of Riot it's required to
provide the Tray icon on Ubuntu.

Fixes #54 