### PR TITLE
Upgrade to version 1.3.5

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.3.5" date="2019-09-16"/>
     <release version="1.3.0" date="2019-07-19"/>
     <release version="1.2.4" date="2019-07-11"/>
     <release version="1.2.3" date="2019-07-08"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -42,14 +42,14 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://packages.riot.im/debian/pool/main/r/riot-web/riot-web_1.3.0_amd64.deb",
-                    "sha256": "dca212121e9c3d2aae6b75cf37d3bb3fe31f3826eca89b52c1e1e320872630c2"
+                    "url": "https://packages.riot.im/debian/pool/main/r/riot-web/riot-web_1.3.5_amd64.deb",
+                    "sha256": "28674d7a55a4ba3c5c6cbd7642e2438912d0f6e2acd93c9747d358dd6a54621d"
                 },
                 {
                     "type": "script",
                     "dest-filename": "riot.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME /app/Riot/riot-web \"$@\""
+                        "exec env TMPDIR=$XDG_CACHE_HOME /app/Riot/riot-web --no-sandbox \"$@\""
                     ]
                 },
                 {
@@ -62,8 +62,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.3.0/riot-v1.3.0.tar.gz",
-                    "sha256": "d8774ebc9d645a64ef10a618249b143167ce8f49913ef8c6710b804a18ebf7e6"
+                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.3.5/riot-v1.3.5.tar.gz",
+                    "sha256": "cf182b354ee18973a76db35ffb4942c93de57190b6532245d13cc3bc73d9ee6e"
                 }
             ]
         }


### PR DESCRIPTION
This upgrade also contains a temporary disabling of the electron
sandbox. Since we don't ship SUID binaries in flatpaks and neasted user
namespaces are still not a thing, this is the only way to have electron
5 applications running within flatpak.

As soon as the flatpak upstream found a better solution, we'll switch to
it and remove the `--no-sandbox` option again.

Reference: https://github.com/flatpak/flatpak/issues/3044