### PR TITLE
Switch runtime to 19.04

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -3,7 +3,7 @@
     "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "18.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "riot",
     "rename-icon": "riot-web",


### PR DESCRIPTION
In order to keep our software up-to-date, lets switch the runtime
version to the latest and greatest 19.08.

Fixes #63 