### PR TITLE
Use 19.08 baseapp version

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "im.riot.Riot",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "18.08",
+    "base-version": "19.08",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",


### PR DESCRIPTION
Mixing different runtime and baseapp versions may accidentally work but in general it's not recommended.