### PR TITLE
Upgrade to version 1.5.1

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.5.1" date="2019-11-04"/>
     <release version="1.5.0" date="2019-10-18"/>
     <release version="1.4.2" date="2019-10-04"/>
     <release version="1.4.1" date="2019-10-01"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -42,8 +42,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://packages.riot.im/debian/pool/main/r/riot-web/riot-web_1.5.0_amd64.deb",
-                    "sha256": "11bf9d1d4434479a88b7785496c22a0c8ab2ce8fe26bb9e904ab6d363392cbd9"
+                    "url": "https://packages.riot.im/debian/pool/main/r/riot-web/riot-web_1.5.1_amd64.deb",
+                    "sha256": "1ba3bfab4966ae549d863f78bf27c83eb53a92d369a236777cc96f47f801d7f1"
                 },
                 {
                     "type": "script",
@@ -62,8 +62,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.5.0/riot-v1.5.0.tar.gz",
-                    "sha256": "2445ad7e6750a90394f783a3ffa41408bb73741247370bf1e7c33b66c7212923"
+                    "url": "https://github.com/vector-im/riot-web/archive/v1.5.1.tar.gz",
+                    "sha256": "14a92f8465559675f401b4e650ae9a65b04f6fc6b625cbf602dd183ab9a3496e"
                 }
             ]
         }


### PR DESCRIPTION
There is also 1.5.2, but it appears macOS specific and I didn't see a .deb for it.