### PR TITLE
Use Zypak for the sandbox

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -24,6 +24,16 @@
     ],
     "modules": [
         {
+            "name": "zypak",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/refi64/zypak",
+                    "tag": "v2019.11beta.3"
+                }
+            ]
+        },
+        {
             "name": "riot",
             "buildsystem": "simple",
             "build-commands": [
@@ -49,7 +59,7 @@
                     "type": "script",
                     "dest-filename": "riot.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME /app/Riot/riot-web --no-sandbox \"$@\""
+                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/Riot/riot-web\"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
**Do NOT merge this into master, please merge into a new beta branch instead!**

This PR adds support for keeping the sandbox via [zypak](https://github.com/refi64/zypak). Once everything is confirmed to be stable, I'll send another PR to a new zypak non-beta release, which should be ready to merge onto master. (You can also subscribe to release notifications for the zypak repository to watch future releases.)