### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -49,7 +49,8 @@
                     "type": "script",
                     "dest-filename": "riot.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME /app/Riot/riot-web --no-sandbox \"$@\""
+                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+                        "exec zypak-wrapper /app/Riot/riot-web \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Also use non-persistent TMPDIR path as original /tmp would be.