### PR TITLE
Remove redundant source

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -67,11 +67,6 @@
                 {
                     "type": "file",
                     "path": "im.riot.Riot.desktop"
-                },
-                {
-                    "type": "archive",
-                    "url": "https://github.com/vector-im/riot-web/releases/download/v1.5.10/riot-v1.5.10.tar.gz",
-                    "sha256": "d6ba1fde93e66e465431cfc84bf487c78e75ed25ce8d991c6068dc0112ea21b0"
                 }
             ]
         }


### PR DESCRIPTION
The deb contains same content in  `/opt/Riot/resources/webapp` which is copied to `/Riot/resources/webapp` so github sources are just unnecessary duplicates.