### PR TITLE
Add riot:// scheme handler

### DIFF
--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -4,3 +4,4 @@ Name=Riot
 Icon=im.riot.Riot
 Exec=/app/bin/riot
 Categories=Network;InstantMessaging;Chat;VideoConference;
+MimeType=x-scheme-handler/riot;

--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Riot
 Icon=im.riot.Riot
-Exec=/app/bin/riot
+Exec=/app/bin/riot %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
 MimeType=x-scheme-handler/riot;


### PR DESCRIPTION
This allows Riot to work with SSO sign in so the homeserver can
redirect the user back to the Riot application after they have
logged in.

This was added recently to be compatible with the new SSO login flows.

Note that there are a few other fields missing from the flatpak's desktop file, I don't know if this is intentional. The full desktop file (generated by electron-builder) is:
```
[Desktop Entry]
Name=Riot
Exec=/opt/Riot/riot-web %U
Terminal=false
Type=Application
Icon=riot-web
StartupWMClass=riot
Comment=A feature-rich client for Matrix.org
MimeType=x-scheme-handler/riot;
Categories=Network;InstantMessaging;Chat;
```

This is also included in the deb file if it's easier to use that, patching as necessary.