### PR TITLE
Upgrade to Riot-desktop 1.6.0

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.0" date="2020-05-05"/>
     <release version="1.5.15" date="2020-04-01"/>
     <release version="1.5.14" date="2020-03-30"/>
     <release version="1.5.13" date="2020-03-17"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -6,7 +6,7 @@
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "riot",
-    "rename-icon": "riot-web",
+    "rename-icon": "riot-desktop",
     "copy-icon": true,
     "separate-locales": false,
     "finish-args": [
@@ -24,16 +24,66 @@
     ],
     "modules": [
         {
+            "name": "tcl",
+            "subdir": "unix",
+            "build-options": {
+                "no-debuginfo": true
+            },
+            "cleanup": [
+                "/bin",
+                "/man"
+            ],
+            "sources": [
+                {
+                "type": "archive",
+                "url": "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.8/tcl8.6.8-src.tar.gz",
+                "sha256": "c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a"
+                }
+            ]
+        },
+        {
+            "name": "sqlcipher",
+            "rm-configure": true,
+            "config-opts": [
+                "--enable-tempstore=yes",
+                "--disable-tcl"
+            ],
+            "build-options": {
+                "cflags": "-DSQLITE_HAS_CODEC",
+                "ldflags": "-lcrypto"
+            },
+            "sources": [
+                {
+                "type": "archive",
+                "url": "https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.tar.gz",
+                "sha256": "fccb37e440ada898902b294d02cde7af9e8706b185d77ed9f6f4d5b18b4c305f"
+                },
+                {
+                "type": "shell",
+                "commands": [
+                    "cp -p /usr/share/automake-*/config.{sub,guess} ."
+                ]
+                },
+                {
+                "type": "script",
+                "dest-filename": "autogen.sh",
+                "commands": [
+                    "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                ]
+                }
+            ]
+        },
+        {
             "name": "riot",
             "buildsystem": "simple",
             "build-commands": [
-                "ar x riot-web_*.deb",
-                "rm -f riot-web_*.deb",
+                "ar x riot-desktop_*.deb",
+                "rm -f riot-desktop_*.deb",
                 "tar xf data.tar.xz",
                 "cp -r opt/* /app",
                 "mkdir -p /app/share/icons/hicolor",
                 "cp -r usr/share/icons/hicolor/* /app/share/icons/hicolor",
-                "chmod -R a-s,go+rX,go-w /app/Riot",
+                "chmod -R a-s,go+rX,go-w \"/app/Riot\"",
                 "install riot.sh /app/bin/riot",
                 "install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop",
                 "install -Dm644 im.riot.Riot.appdata.xml /app/share/appdata/im.riot.Riot.appdata.xml"
@@ -44,11 +94,11 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://packages.riot.im/debian/pool/main/r/riot-web/riot-web_1.5.15_amd64.deb",
-                    "sha256": "8a253bb037cb68e5a5a67b7204a76bb529f76a8303fd9de44ace6f41acb58299",
+                    "url": "https://packages.riot.im/debian/pool/main/r/riot-desktop/riot-desktop_1.6.0_amd64.deb",
+                    "sha256": "d768b227f916ef42aae46114340189349e1015516cb1ef16c2c0ec07efba5ca3",
                     "x-checker-data": {
                         "type": "debian-repo",
-                        "package-name": "riot-web",
+                        "package-name": "riot-desktop",
                         "root": "https://packages.riot.im/debian",
                         "dist": "sid",
                         "component": "main"
@@ -60,7 +110,7 @@
                     "dest-filename": "riot.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper /app/Riot/riot-web \"$@\""
+                        "exec zypak-wrapper \"/app/Riot/riot-desktop\" \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Upgrading to the new release 1.6.0 with all needed dependency changes to use the new riot-desktop package, build the required dependencies and offer full-featured cross-signing with search indexing etc.
