### PR TITLE
Stop using out-of-date release of Tcl

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.8/tcl8.6.8-src.tar.gz",
-                    "sha256": "c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a"
+                    "url": "https://prdownloads.sourceforge.net/tcl/tcl8.6.10-src.tar.gz",
+                    "sha256": "5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed"
                 }
             ]
         },


### PR DESCRIPTION
PR #96 introduced new build dependencies, including Tcl 8.6.8, which was [released in 2017](https://sourceforge.net/projects/tcl/files/Tcl/8.6.8/tcltk-release-notes-8.6.8.txt/view).

If we must use Tcl, let's use the [currently supported release](https://www.tcl-lang.org/software/tcltk/download.html): 8.6.10