### PR TITLE
Cleanup new dependencies

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -46,8 +46,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.8/tcl8.6.8-src.tar.gz",
-                    "sha256": "c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a"
+                    "url": "https://downloads.sourceforge.net/sourceforge/tcl/tcl8.6.10-src.tar.gz",
+                    "sha256": "5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed"
                 }
             ]
         },

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -22,6 +22,19 @@
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--filesystem=xdg-run/keyring"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/lib/*.a",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/share/gtk-doc",
+        "/share/doc",
+        "/share/info",
+        "/share/man",
+        "/man"
+    ],
     "modules": [
         {
             "name": "tcl",

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -42,10 +42,7 @@
             "build-options": {
                 "no-debuginfo": true
             },
-            "cleanup": [
-                "/bin",
-                "/man"
-            ],
+            "cleanup": [ "*" ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
~~According to riot sources they link to [sqlcipher statically](https://github.com/vector-im/riot-desktop/blob/bcb0611ee3504efe4e0054504214cd8c11ea7d1b/hak/matrix-seshat/build.js#L46) so we don't have to provide sqlcipher in flapak at all. I checked that nothing in riot binaries dynamically links to sqlcipher or tcl.~~

Tcl is only build dep and can be  cleaned out completely. Also clean other stuff like static libs which add significant amount of size and are unnecessary.