### PR TITLE
Add KDE notification dbus ownership

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -20,6 +20,7 @@
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--own-name=org.kde.StatusNotifierItem-2-1",
         "--filesystem=xdg-run/keyring"
     ],
     "cleanup": [


### PR DESCRIPTION
For the tray icon in KDE it's required to own the dbus of a naming
schema following `org.kde.KStatusNotifier-x-y`, where x is the
application's PID and y is an application's unique identifier. [1]

This change might introduces conflicts with other flatpaks that also try
to own this dbus name. If that happens, the tray icon might still won't
work. This should be kept in mind with this change. It's also
noteworthy, that this might breaks on any update and therefore should be
tested by people.

This entire change is required due to electron dropping `xembed`
support and Riot was upgrading Electron with 1.6.0.[2] If you are using
GNOME with tray icons there is a GNOME extension to help.[3]

An alternative implementation could have added `--own-name=org.kde.*`,
like the Zoom flatpak does for example[1], but was dismissed in order to
prevent more conflicts than needed.[4]

[1]: https://github.com/flathub/us.zoom.Zoom/commit/348ff4e59ac6cc8104a729710dd11dba67147f51
[2]: https://matrix.to/#/!YTvKGNlinIzlkMTVRl:matrix.org/$xSOdy7v9Bu3SGHFgQm98OH0uROsN4e5k-5bPYYA9O-I?via=matrix.org&via=privacytools.io&via=mozilla.org
[3]: https://extensions.gnome.org/extension/615/appindicator-support/
[4]: https://github.com/flathub/im.riot.Riot/issues/100#issuecomment-625796916