### PR TITLE
Fix compatiblity with old flatpak versions

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -145,7 +145,7 @@
                     "type": "script",
                     "dest-filename": "element.sh",
                     "commands": [
-                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-im.riot.Riot}\"",
                         "exec zypak-wrapper \"/app/Element/element-desktop\" \"$@\""
                     ]
                 },


### PR DESCRIPTION
Old flatpak versions don't provide the `FLATPAK_ID` environment
variable. Therefore the script we use to start Riot fails to use correct
temporary directory which results in duplicated Riot instances trying to
run on the same configuration, which ultimately fails.

This patch fixes the whole problem by providing a fallback default which
should match.

Fixes #116 