### PR TITLE
Rebrand Riot to Element

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>im.riot.Riot.desktop</id>
-  <name>Riot</name>
+  <name>Element</name>
   <project_license>Apache-2.0</project_license>
   <developer_name>New Vector Ltd</developer_name>
   <summary>Create, share, communicate, chat and call securely, and bridge to other apps</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <url type="homepage">https://about.riot.im/</url>
+  <url type="homepage">https://element.io/</url>
   <description>
     <p>More than group chat: communication</p>
     <ul>
@@ -19,16 +19,12 @@
   </description>
   <screenshots>
     <screenshot>
-      <image type="source">https://cdn-images-1.medium.com/max/900/1*HW0bNUALtn1refBjK25dXw.png</image>
-    </screenshot>
-    <screenshot>
-      <image type="source">https://cdn-images-1.medium.com/max/900/1*dsciAZ4PifHfaTgqWsahpQ.png</image>
-    </screenshot>
-    <screenshot>
-      <image type="source">https://cdn-images-1.medium.com/max/900/1*bilpNcjPIpGfMMa0QvTArg.png</image>
+      <caption>Element logged-in frontend</caption>
+      <image type="source">https://element.io/blog/content/images/2020/07/Screenshot-2020-07-15-at-00.54.45.png</image>
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.7.0" date="2020-07-15"/>
     <release version="1.6.8" date="2020-07-03"/>
     <release version="1.6.7" date="2020-06-29"/>
     <release version="1.6.6" date="2020-06-23"/>

--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -24,6 +24,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.7.1" date="2020-07-16"/>
     <release version="1.7.0" date="2020-07-15"/>
     <release version="1.6.8" date="2020-07-03"/>
     <release version="1.6.7" date="2020-06-29"/>

--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
-Name=Riot
+Name=Element
 Icon=im.riot.Riot
-Exec=/app/bin/riot %U
+Exec=/app/bin/element %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
-MimeType=x-scheme-handler/riot;
+MimeType=x-scheme-handler/element;

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -93,7 +93,7 @@
                 "ar x element-desktop_*.deb",
                 "rm element-desktop_*.deb",
                 "tar xf data.tar.xz",
-                "cp -r 'opt/Element (Riot)' /app/Element",
+                "cp -r 'opt/Element' /app/Element",
                 "mkdir -p /app/share/icons/hicolor",
                 "cp -r usr/share/icons/hicolor/* /app/share/icons/hicolor",
                 "chmod -R a-s,go+rX,go-w \"/app/Element\"",
@@ -107,8 +107,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.7.0_amd64.deb",
-                    "sha256": "64cbae67fb0a3c200db5349531d0c9b383bfa8b709e356974b0060f65e01cc2b",
+                    "url": "https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.7.1_amd64.deb",
+                    "sha256": "6b5fdbed7ec8fc50b9729452b2a022bd6e4e9d85a4318776b1dbe03f1b29ae5f",
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "element-desktop",

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -5,8 +5,8 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "riot",
-    "rename-icon": "riot-desktop",
+    "command": "element",
+    "rename-icon": "element-desktop",
     "copy-icon": true,
     "separate-locales": false,
     "finish-args": [
@@ -90,14 +90,14 @@
             "name": "riot",
             "buildsystem": "simple",
             "build-commands": [
-                "ar x riot-desktop_*.deb",
-                "rm -f riot-desktop_*.deb",
+                "ar x element-desktop_*.deb",
+                "rm element-desktop_*.deb",
                 "tar xf data.tar.xz",
-                "cp -r opt/* /app",
+                "cp -r 'opt/Element (Riot)' /app/Element",
                 "mkdir -p /app/share/icons/hicolor",
                 "cp -r usr/share/icons/hicolor/* /app/share/icons/hicolor",
-                "chmod -R a-s,go+rX,go-w \"/app/Riot\"",
-                "install riot.sh /app/bin/riot",
+                "chmod -R a-s,go+rX,go-w \"/app/Element\"",
+                "install element.sh /app/bin/element",
                 "install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop",
                 "install -Dm644 im.riot.Riot.appdata.xml /app/share/appdata/im.riot.Riot.appdata.xml"
             ],
@@ -107,11 +107,11 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://packages.riot.im/debian/pool/main/r/riot-desktop/riot-desktop_1.6.8_amd64.deb",
-                    "sha256": "5d0432129fa74893db728016895f0b19271a8004f943999e4bc1895ee306ce3f",
+                    "url": "https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.7.0_amd64.deb",
+                    "sha256": "64cbae67fb0a3c200db5349531d0c9b383bfa8b709e356974b0060f65e01cc2b",
                     "x-checker-data": {
                         "type": "debian-repo",
-                        "package-name": "riot-desktop",
+                        "package-name": "element-desktop",
                         "root": "https://packages.riot.im/debian",
                         "dist": "sid",
                         "component": "main"
@@ -120,10 +120,10 @@
                 },
                 {
                     "type": "script",
-                    "dest-filename": "riot.sh",
+                    "dest-filename": "element.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper \"/app/Riot/riot-desktop\" \"$@\""
+                        "exec zypak-wrapper \"/app/Element/element-desktop\" \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Riot was renamed to Element by the upstream project and recieved an
update to version 1.7.0 as part of the rebranding. With some discussions
in the project there is the expectation to **not** change the
application ID of the flatpak just because the application was
renamed. Therefore this patch only updates the visible indicators
but keeps the app-ID identical.

This patch renames all visible indicators from Riot to Element, upgrades
Element to version 1.7.0 and fixes the build system were needed.
Otherwise the flatpak itself stays the same, we still repackage the
upstream `.deb` as well as using the `im.riot.Riot` app-ID.

https://element.io/blog/welcome-to-element/
https://github.com/flathub/im.riot.Riot/issues/114