### PR TITLE
Fix broken search for encrypted messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -18,7 +18,6 @@
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.portal.Fcitx",
-        "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.kde.StatusNotifierItem-2-1",
         "--filesystem=xdg-run/keyring"
@@ -37,6 +36,7 @@
         "/man"
     ],
     "modules": [
+        "shared-modules/libsecret/libsecret.json",
         {
             "name": "tcl",
             "subdir": "unix",


### PR DESCRIPTION
It seems like encrypted search needs libsecret now. This patch provides
libsecret and should fix the problem therefore. It also removes the
unneeded permission for `org.freedesktop.secrets` as that's now handled
by libsecret and (if I recall correct) a portal.

Fixes #123 