### PR TITLE
Add Window Startup class

### DIFF
--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -5,3 +5,4 @@ Icon=im.riot.Riot
 Exec=/app/bin/element %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
 MimeType=x-scheme-handler/element;
+StartupWMClass=element (riot)


### PR DESCRIPTION
This patch adds the window startup class to the desktop file to make
sure things are grouped properly.

Fixes #121