### PR TITLE
Fix window class name for 1.7.2

### DIFF
--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -5,4 +5,4 @@ Icon=im.riot.Riot
 Exec=/app/bin/element %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
 MimeType=x-scheme-handler/element;
-StartupWMClass=element (riot)
+StartupWMClass=element


### PR DESCRIPTION
This patch fixes the previous change of the `StartUpWMClass` that we
introduced two commits ago. To fix the messed up windows pinning. Now we
change it again, as upstream decided to change the window name again.