### PR TITLE
Upgrade runtime 20.08 and enable file-picker support in zypak

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -15,7 +15,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.kde.StatusNotifierWatcher",
@@ -123,6 +122,7 @@
                     "dest-filename": "element.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+                        "export ZYPAK_FORCE_FILE_PORTAL=1",
                         "exec zypak-wrapper \"/app/Element/element-desktop\" \"$@\""
                     ]
                 },

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -1,9 +1,9 @@
 {
     "app-id": "im.riot.Riot",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "19.08",
+    "base-version": "20.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "element",
     "rename-icon": "element-desktop",


### PR DESCRIPTION
This patch will force electron to use the gtk portal as file-picker. This
allows us to drop all directory access for the app without losing access
to file. This will fix drag-drop support as well as saving and uploading
files in Riot without requiring any special permissions.

Thanks a lot @refi64 for implementing this feature into the zypak!

Fixes #33