### PR TITLE
[DO NOT MERGE] Try latest Zypak version

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -86,6 +86,7 @@
                 }
             ]
         },
+        { "name": "zypak", "sources": [{ "type": "git", "url": "https://github.com/refi64/zypak", "commit": "3f8407fd481034f142b3f182e85a78989bc02ce1" }] },
         {
             "name": "riot",
             "buildsystem": "simple",


### PR DESCRIPTION
Running a build on Flathub to determine if #152 is fixed. @DemiMarie try running both normally and with `flatpak run --env=ZYPAK_ZYGOTE_STRATEGY_SPAWN=0`, see if they both work.