### PR TITLE
Add wayland support with electron version 12

### DIFF
--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -11,7 +11,8 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
@@ -122,7 +123,7 @@
                     "dest-filename": "element.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper \"/app/Element/element-desktop\" \"$@\""
+                        "exec zypak-wrapper \"/app/Element/element-desktop\" --enable-features=UseOzonePlatform --ozone-platform=wayland \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
This patch enables wayland support introduced in electron version 12 for
the Element flatpak.