### PR TITLE
Element 1.7.25 and Wayland support

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -16,6 +16,11 @@
       <li>Grab the attention of your colleague by calling out their name and don’t miss a thing with keyword alerts.</li>
       <li>Deploy bots for fun or practical use with our integrations store.</li>
     </ul>
+    <p>Preliminary Wayland support since 1.7.25. You can
+      <code>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</code>
+      to try out running Element natively under Wayland. For GNOME window decorations will be missing
+      and you'll have to use keyboard shortcuts instead to resize the window.
+    </p>
   </description>
   <screenshots>
     <screenshot>

--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -16,11 +16,9 @@
       <li>Grab the attention of your colleague by calling out their name and don’t miss a thing with keyword alerts.</li>
       <li>Deploy bots for fun or practical use with our integrations store.</li>
     </ul>
-    <p>Preliminary Wayland support since 1.7.25. You can
-      <code>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</code>
-      to try out running Element natively under Wayland. For GNOME window decorations will be missing
-      and you'll have to use keyboard shortcuts instead to resize the window.
-    </p>
+    <p>Preliminary Wayland support since 1.7.25.</p>
+    <p>To try running Element natively under Wayland, run: <code>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</code></p>
+    <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
   </description>
   <screenshots>
     <screenshot>

--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -24,6 +24,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.7.25" date="2021-04-12"/>
     <release version="1.7.24" date="2021-03-29"/>
     <release version="1.7.23" date="2021-03-15"/>
     <release version="1.7.22" date="2021-03-01"/>

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -20,7 +20,8 @@
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.kde.StatusNotifierItem-2-1",
-        "--filesystem=xdg-run/keyring"
+        "--filesystem=xdg-run/keyring",
+        "--filesystem=xdg-run/pipewire-0"
     ],
     "cleanup": [
         "/include",
@@ -83,6 +84,28 @@
                     "commands": [
                         "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
                     ]
+                }
+            ]
+        },
+        {
+            "name": "pipewire",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dgstreamer=disabled",
+                "-Dman=false",
+                "-Dsystemd=false"
+            ],
+            "cleanup": [
+                "/include",
+                "/bin",
+                "/etc",
+                "/lib/pkgconfig"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/PipeWire/pipewire.git",
+                    "tag": "0.2.7"
                 }
             ]
         },

--- a/im.riot.Riot.json
+++ b/im.riot.Riot.json
@@ -107,8 +107,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.7.24_amd64.deb",
-                    "sha256": "44e978970ac5a511d4ba83364a76d81041ccd71129e57cdd8384cd460ff9bd35",
+                    "url": "https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.7.25_amd64.deb",
+                    "sha256": "1487cc34a8b4debbb11847781e4d6f39288a01a03064f26bf54d66486a7278b7",
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "element-desktop",


### PR DESCRIPTION
As of Element 1.7.25, Electron 12 is used which enables people to start it with `--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland` and try out full Wayland support