### PR TITLE
Move Wayland info to README and add disclaimer to AppInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Element Desktop
+
+More than group chat: communication.
+
+* Communicate with your team and out of network colleagues more efficiently: use dedicated rooms which persist information from their creation and forever.
+* Forget group emails: join or create rooms per topic, per team, per event… Decide the level of transparency you want to provide across the organisation or project.
+* Cut through the noise by creating notifications that are customised by you and for you.
+* Grab the attention of your colleague by calling out their name and don’t miss a thing with keyword alerts.
+* Deploy bots for fun or practical use with our integrations store.
+
+![Element logged-in frontend](https://element.io/blog/content/images/2020/07/Screenshot-2020-07-15-at-00.54.45.png)
+
+## Disclaimer
+
+The Flathub distribution of Element is community maintained and not affiliated with or officially supported by [Element Software, Inc.](https://element.io/). The Flathub distribution of Element has several known known issues, including broken functionality. To install the officially supported version of Element (Debian/Ubuntu only), visit [the official Element website](https://element.io/get-started).
+
+For known issues, visit the [Issues](https://github.com/flathub/im.riot.Riot/issues) page above. Please do not report bugs to the upstream Element maintainers unless you can consistently reproduce them on the official distribution.
+
+## Experimental Features
+
+### Preliminary Wayland support since 1.7.25.
+
+To try running Element natively under Wayland, run:
+```bash
+$ flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot
+```
+For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.

--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -3,10 +3,13 @@
   <id>im.riot.Riot.desktop</id>
   <name>Element</name>
   <project_license>Apache-2.0</project_license>
-  <developer_name>New Vector Ltd</developer_name>
+  <developer_name>Element Software, Inc.</developer_name>
   <summary>Create, share, communicate, chat and call securely, and bridge to other apps</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://element.io/</url>
+  <url type="faq">https://github.com/flathub/im.riot.Riot/</url>
+  <url type="bugtracker">https://github.com/flathub/im.riot.Riot/issues</url>
+  <url type="help">https://element.io/help</url>
   <description>
     <p>More than group chat: communication</p>
     <ul>
@@ -16,9 +19,7 @@
       <li>Grab the attention of your colleague by calling out their name and don’t miss a thing with keyword alerts.</li>
       <li>Deploy bots for fun or practical use with our integrations store.</li>
     </ul>
-    <p>Preliminary Wayland support since 1.7.25.</p>
-    <p>To try running Element natively under Wayland, run: <code>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</code></p>
-    <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
+    <p>NOTE: the Flathub distribution of Element is community maintained and not affiliated with or officially supported by Element Software, Inc. The Flathub distribution of Element has several known known issues, including broken functionality. To install the officially supported version of Element (Debian/Ubuntu only), visit the page labeled "Homepage". For known issues and experimental features, visit the pages labeled "Bugtracker" and "FAQ". Please do not report bugs to the upstream Element maintainers unless you can consistently reproduce them on the official distribution.</p>
   </description>
   <screenshots>
     <screenshot>


### PR DESCRIPTION
Including a disclaimer might make the official Element maintainers be more inclined to [acknowledge](https://github.com/vector-im/element.io/issues/18) that this distribution exists. (Actually “adopting” this distribution and helping to [fix](https://github.com/vector-im/element-web/issues/3718) some of the known issues of the Flatpak does not seem to be a priority for them, though.)

@vector-im tagging you in case you want to weigh in the inclusion of a disclaimer.