### PR TITLE
Add keywords to desktop file

### DIFF
--- a/im.riot.Riot.desktop
+++ b/im.riot.Riot.desktop
@@ -6,3 +6,4 @@ Exec=/app/bin/element %U
 Categories=Network;InstantMessaging;Chat;VideoConference;
 MimeType=x-scheme-handler/element;
 StartupWMClass=element
+Keywords=Matrix;matrix.org;chat;irc;communications;talk;riot;vector;


### PR DESCRIPTION
I borrowed all of these from org.gnome.Fractal.desktop, then added
'vector' to the untranslated key. (Before it was called Riot, Element
was called Vector.)

Fixes #138
