### PR TITLE
Fix code tags in desktop metadata

### DIFF
--- a/im.riot.Riot.appdata.xml
+++ b/im.riot.Riot.appdata.xml
@@ -17,7 +17,8 @@
       <li>Deploy bots for fun or practical use with our integrations store.</li>
     </ul>
     <p>Preliminary Wayland support since 1.7.25.</p>
-    <p>To try running Element natively under Wayland, run: <code>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</code></p>
+    <p>To try running Element natively under Wayland, run:</p>
+    <p>flatpak run --socket=wayland --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland im.riot.Riot</p>
     <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
   </description>
   <screenshots>


### PR DESCRIPTION
While the spec officially supports `<em>` and `<code>`-tags, the
libraries used by the flathub frontend as well as GNOME software, don't
support these tags and just strip them, resulting in a non-functional
description for the flatpak on multiple platforms. While the right way
to do it, would be to fix to be applied to the upstream version of the
appstream-glib library, this doesn't seem to happen any time soon.

Therefore this patch removes the usage of the `<code>` and replaces it
with supported `<p>` tags, which might result in broken syntax if the
fonts substitute characters. That's nothing we can change.

References:
https://github.com/guinux/appstream-glib/commit/7fef9b4e0f2bbb33bd0f036413f3523ca5e821b8
https://github.com/flathub/linux-store-frontend/issues/203

Partly resolves issue mentioned in #180 