### PR TITLE
Remove PipeWire module and metainfo mention

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -20,7 +20,7 @@
     </ul>
     <p>Preliminary Wayland support since 1.7.25.</p>
     <p>To try running Element natively under Wayland, run:</p>
-    <p>flatpak run im.riot.Riot --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland</p>
+    <p>flatpak run im.riot.Riot --enable-features=UseOzonePlatform --ozone-platform=wayland</p>
     <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
   </description>
   <screenshots>

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -80,21 +80,6 @@ modules:
         dest-filename: autogen.sh
         commands:
           - AUTOMAKE="automake --foreign" autoreconf -vfi
-  - name: pipewire
-    buildsystem: meson
-    config-opts:
-      - -Dgstreamer=disabled
-      - -Dman=false
-      - -Dsystemd=false
-    cleanup:
-      - /include
-      - /bin
-      - /etc
-      - /lib/pkgconfig
-    sources:
-      - type: git
-        url: https://github.com/PipeWire/pipewire.git
-        tag: 0.2.7
   - name: riot
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This makes most sense to merge once Element does a new release, this isn't urgent or anything, just cleanup.

-Don't need PipeWire 0.2.7 module since Element builds against Electron 13, which supports PipeWire 0.3
-PipeWire 0.3 is included in the runtime.
-Mentioning the flag in the metainfo descrption will be redundant as of the next Element release (>1.8.1), see https://github.com/vector-im/element-web/issues/18607