### PR TITLE
Re-add PipeWire capturer to flags in desktop file

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -20,7 +20,7 @@
     </ul>
     <p>Preliminary Wayland support since 1.7.25.</p>
     <p>To try running Element natively under Wayland, run:</p>
-    <p>flatpak run im.riot.Riot --enable-features=UseOzonePlatform --ozone-platform=wayland</p>
+    <p>flatpak run im.riot.Riot --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland</p>
     <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
   </description>
   <screenshots>


### PR DESCRIPTION
This should be merged next update.

By default if the user starts the app normally the PipeWire capturer flag is passed (https://github.com/vector-im/element-desktop/pull/256).
However since Chromium only can use one instance of `--enable-features`, this will break usage of custom `--enable-features` flags from the user. This means the flags for Wayland won't work. This is the state of things as of 1.8.4.

So it was changed upstream https://github.com/vector-im/element-desktop/pull/261/commits/96e5389779f60c91b8fe80d7bd9af413d72ec61f if the user passed their own enable-features flags the upstream setting of the PipeWire flag is ignored, so now that means users need to make sure to pass the PipeWire flag along with the Ozone ones if they want native Wayland. This upstream change should make it in 1.8.5.