### PR TITLE
chore(update): org.freedesktop.Platform 21.08

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -1,8 +1,8 @@
 app-id: im.riot.Riot
 base: org.electronjs.Electron2.BaseApp
-base-version: '20.08'
+base-version: '21.08'
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: element
 rename-icon: element-desktop


### PR DESCRIPTION
Update to latest and greatest Freedesktop 21.08 runtime. Tested this build locally and LGTM so far.