### PR TITLE
Update screenshot to show app

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -26,7 +26,7 @@
   <screenshots>
     <screenshot>
       <caption>Element logged-in frontend</caption>
-      <image type="source">https://element.io/blog/content/images/2020/07/Screenshot-2020-07-15-at-00.54.45.png</image>
+      <image type="source">https://user-images.githubusercontent.com/2221064/137519256-655fe0f9-55f0-44a4-b681-83711654fff0.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
Update screenshot to show app instead of web browser.
Previous screenshot showcased the website in a browser.

Fixes #188