### PR TITLE
Pass an explicit TMPDIR for app.requestSingleInstanceLock to work

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -38,6 +38,10 @@ finish-args:
   - --filesystem=xdg-run/keyring
   # Required for experimental wayland support
   - --filesystem=xdg-run/pipewire-0
+  # Required for app.requestSingleInstanceLock to work 
+  # https://github.com/vector-im/element-web/issues/18625#issuecomment-958947704
+  - --env=TMPDIR=/var/tmp
+  
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
Hoping to fix https://github.com/vector-im/element-web/issues/18625

This is suggested at https://github.com/flathub/org.electronjs.Electron2.BaseApp/issues/4#issuecomment-432258301