### PR TITLE
Remove wrong gnome csd info

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -21,7 +21,6 @@
     <p>Preliminary Wayland support since 1.7.25.</p>
     <p>To try running Element natively under Wayland, run:</p>
     <p>flatpak run im.riot.Riot --enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland</p>
-    <p>For GNOME, window decorations are currently missing and you'll have to use keyboard shortcuts instead to resize the window.</p>
   </description>
   <screenshots>
     <screenshot>


### PR DESCRIPTION
I don't think this is true anymore, at least it seems to work for me.