### PR TITLE
Update to 1.9.7 (security release)

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -30,6 +30,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.9.7" date="2021-12-13"/>
     <release version="1.9.6" date="2021-12-06"/>
     <release version="1.9.5" date="2021-11-22"/>
     <release version="1.9.4" date="2021-11-08"/>

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -99,12 +99,12 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://packages.riot.im/debian/pool/main/e/element-desktop/element-desktop_1.9.6_amd64.deb
-        sha256: 0109e2fb3ab6369a239bcd9b8fefabff64347a284169a9f56d2314e90e004f07
+        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.9.7_amd64.deb
+        sha256: c8c5f7ac3990e264510e0860da7c169bb4a3b0fac8636f6a727809d9aab770eb
         x-checker-data:
           type: debian-repo
           package-name: element-desktop
-          root: https://packages.riot.im/debian
+          root: https://packages.element.io/debian
           dist: sid
           component: main
       - type: file


### PR DESCRIPTION
https://matrix.org/blog/2021/12/13/disclosure-buffer-overflow-in-libolm-and-matrix-js-sdk