### PR TITLE
fix(permissions): Remove unused keyring mount

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,8 +34,6 @@ finish-args:
   - --own-name=org.kde.StatusNotifierItem-2-1
   # Required for advanced input methods e.g. writing CJK languages
   - --talk-name=org.freedesktop.portal.Fcitx
-  # Required to store access tokens (persistent logins)
-  - --filesystem=xdg-run/keyring
   # Required for experimental wayland support
   - --filesystem=xdg-run/pipewire-0
 cleanup:


### PR DESCRIPTION
This patch removes the keyring mount since it's no longer required
thanks to portals for libsecret.

References:
https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-org.freedesktop.portal.Secret