### PR TITLE
fix(permission): Re-add keyring mount

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,6 +34,8 @@ finish-args:
   - --own-name=org.kde.StatusNotifierItem-2-1
   # Required for advanced input methods e.g. writing CJK languages
   - --talk-name=org.freedesktop.portal.Fcitx
+  # Required to store access tokens (persistent logins)
+  - --filesystem=xdg-run/keyring
   # Required for experimental wayland support
   - --filesystem=xdg-run/pipewire-0
 cleanup:


### PR DESCRIPTION
As it turns out, removing it, introduces some instability in session
storage, resulting in unexpected logout events.

Revert "fix(permissions): Remove unused keyring mount"

This reverts commit 80a290dfb90f7343c1391957bcd4f6ab20d33e43.

Fixes #272 