### PR TITLE
Allow access to common xdg directories

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -24,7 +24,12 @@ finish-args:
   - --share=network
   # Allows to send and receive files in the Downloads directory
   # Required until Electron supports portals for load and safe dialogs
+  - --filesystem=xdg-desktop:ro
+  - --filesystem=xdg-documents:ro
   - --filesystem=xdg-download
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-videos:ro
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -24,12 +24,12 @@ finish-args:
   - --share=network
   # Allows to send and receive files in the Downloads directory
   # Required until Electron supports portals for load and safe dialogs
-  - --filesystem=xdg-desktop:ro
-  - --filesystem=xdg-documents:ro
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-documents
   - --filesystem=xdg-download
-  - --filesystem=xdg-music:ro
-  - --filesystem=xdg-pictures:ro
-  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
Partially fixes #33 and #68

Following the discussions on #33 I can see why we can't allow access to the entire user's home so this would at least help by allowing read-only access to more common directories.