### PR TITLE
fix: Wrong portal versions on too old flatpak

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -9,6 +9,8 @@ rename-icon: element-desktop
 copy-icon: true
 separate-locales: false
 finish-args:
+  # Version required to use the document-portal v4
+  - --require-version=1.7.0
   # Required due to being a GUI application
   - --socket=x11
   # Required to make sure x11 performance is achived on all platforms


### PR DESCRIPTION
This patch drops support for any flatpak version prior to 1.7.0. This is
done to reduce potential overhead regarding old versions of Flatpak.
Instead of failing in hard to understand way, it'll fail to install with
a version provided by the flatpak command.

This will affect versions of Ubuntu and other distros that don't bother
to keep up with current flatpak development.

Be aware that flatpak 1.7.0 is 2 years old.

References:
https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$JUBHbW6cUN6HtZJWdeinQQVHkoi1fnFH4hYuRdSaZcI?via=matrix.org&via=gnome.org&via=kde.org