### PR TITLE
Update element.sh to add wayland support

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -4,7 +4,11 @@ FLAGS=''
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then
-    FLAGS="$FLAGS --disable-gpu-sandbox"
+    if [ -c /dev/nvidia0 ]
+    then
+        FLAGS="$FLAGS --disable-gpu-sandbox"
+    fi
+    FLAGS="$FLAGS --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform=wayland"
 fi
 
 env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-im.riot.Riot}" zypak-wrapper /app/Element/element-desktop $FLAGS "$@"


### PR DESCRIPTION
Adds support for wayland by adding the correct command line arguments.

Note that alternatives like `.config/electron-flags.conf` simply don't work.