### PR TITLE
Removes wayland socket support by default

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -17,8 +17,6 @@ finish-args:
   # At least that's what the legends tell. it might be worth experimenting
   # with dropping this permission.
   - --share=ipc
-  # Required for experimental wayland support
-  - --socket=wayland
   # Required to provide Call functionality
   - --socket=pulseaudio
   - --device=all


### PR DESCRIPTION
Wayland is not supported upstream and leaving it here increases the attack surface for no benefit whatsoever. Worse actually, users could believe wayland is supported when it is not.

For "experimental support" (as specified in the comment), user should use `flatseal` or `flatpak override` directly to enable the socket.