### PR TITLE
fix: Re-add the tray icon support on KDE

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -27,6 +27,8 @@ finish-args:
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  # Required for tray icons on KDE
+  - --own-name=org.kde.*
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver
   # Required for advanced input methods e.g. writing CJK languages


### PR DESCRIPTION
This patch fixes the KDE tray icon support removed in the previous commit by implementing the general recommendation. This will not trigger the flatpak linter and make tray icons work reliably on KDE since it's no longer depending on the exact PID.

References:
https://github.com/flathub/im.riot.Riot/pull/306
https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$gPmHj1ANaVEWBMKx5WbjIU6M86gQ86IC6UE-emQaehQ?via=matrix.org&via=gnome.org&via=kde.org