### PR TITLE
Restrict dbus service ownership to tray icons only

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -27,8 +27,25 @@ finish-args:
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Required for tray icons on KDE
-  - --own-name=org.kde.*
+  # Required for tray icons on KDE until Chromium 9585757 makes it to Electron
+  - --own-name=org.kde.StatusNotifierItem-2-1
+  - --own-name=org.kde.StatusNotifierItem-2-2
+  - --own-name=org.kde.StatusNotifierItem-2-3
+  - --own-name=org.kde.StatusNotifierItem-2-4
+  - --own-name=org.kde.StatusNotifierItem-2-5
+  - --own-name=org.kde.StatusNotifierItem-2-6
+  - --own-name=org.kde.StatusNotifierItem-2-7
+  - --own-name=org.kde.StatusNotifierItem-2-8
+  - --own-name=org.kde.StatusNotifierItem-2-9
+  - --own-name=org.kde.StatusNotifierItem-3-1
+  - --own-name=org.kde.StatusNotifierItem-3-2
+  - --own-name=org.kde.StatusNotifierItem-3-3
+  - --own-name=org.kde.StatusNotifierItem-3-4
+  - --own-name=org.kde.StatusNotifierItem-3-5
+  - --own-name=org.kde.StatusNotifierItem-3-6
+  - --own-name=org.kde.StatusNotifierItem-3-7
+  - --own-name=org.kde.StatusNotifierItem-3-8
+  - --own-name=org.kde.StatusNotifierItem-3-9
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver
   # Required for advanced input methods e.g. writing CJK languages


### PR DESCRIPTION
This reverts 0731361 to (a more flexible version of) the previous approach, to avoid permitting broad ownership of all kde session bus services.

Background:

Freedesktop's StatusNotifierItem spec directs applications to choose a unique session bus name by embedding the process ID.  Of course, that will not be unique when applications run in pid namespaces, as is common in container environments like FlatPak. The spec is poorly designed.

https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/

https://blog.tingping.se/2019/09/07/how-to-design-a-modern-status-icon.html

https://gitlab.freedesktop.org/TingPing/xdg-specs/-/blob/statusicon/status-icon/status-icon-spec.rst

As a result, --own-name=org.kde.StatusNotifierItem-2-1 will only work for the first Flatpak app to claim that name.

We cannot use --own-name=org.kde.StatusNotifierItem-* because Flatpak only supports wildcards at namespace breaks.  The workaround in 0731361 was to allow ownership of the entire org.kde.* namespace, ensuring that status icons would work, but also opening the door to impersonating any service in that hierarchy.

Discussed on 2022-08-12 and 2022-10-25 in the #flatpak:matrix.org Matrix room:

https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$gPmHj1ANaVEWBMKx5WbjIU6M86gQ86IC6UE-emQaehQ

With this patch, we instead individually permit a range of service names following the StatusNotifierItem-$PID-$ID pattern.  It slightly clutters our manifiest file, but aligns much better with Flatpak's sandboxing goals, and (importantly) is far safer from security/privacy exploits.

We allow names in the StatusNotifierItem-3-* range because recent Element flatpaks run as (namespaced) pid 3, and Electron chooses the final digit dynamically:

https://github.com/chromium/chromium/blob/cf6d18b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc#L297

We allow StatusNotifierItem-2-* in case a future Element flatpak runs as pid 2, as it did until recently.

Note that these permissions will probably not be necessary forever, since Chromium is abandoning Freedesktop's flawed naming convention, and Electron will presumably inherit that change, eventually.

https://github.com/chromium/chromium/commit/9585757

https://chromium-review.googlesource.com/c/chromium/src/+/4179380

Fixes flathub/im.riot.Riot#327