### PR TITLE
Remove Electron flags for Ozone platform

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 
-FLAGS=''
+FLAGS="--enable-features=WebRTCPipeWireCapturer"
 
-if [[ $XDG_SESSION_TYPE == "wayland" ]]
+if  [ -c /dev/nvidia0 ]
 then
-    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
-    if  [ -c /dev/nvidia0 ]
-    then
-        FLAGS="$FLAGS --disable-gpu-sandbox"
-    fi
-else
-    FLAGS="$FLAGS --enable-features=WebRTCPipeWireCapturer"
+    FLAGS="$FLAGS --disable-gpu-sandbox"
 fi
 
 env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-im.riot.Riot}" zypak-wrapper /app/Element/element-desktop $FLAGS "$@"


### PR DESCRIPTION
Based on recent issues, there are still Wayland incompatibilities in Element that need to be fixed by upstream. This removes the Ozone platform flags introduced in #325, but keeps `WebRTCPipeWireCapturer`.

Closes #335 . Closes #332. (accidentally tagged the wrong issues)