### PR TITLE
element.sh: Ensure in condition that Wayland socket exists

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -2,7 +2,7 @@
 
 FLAGS=''
 
-if [[ $XDG_SESSION_TYPE == "wayland" ]]
+if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
     if  [ -c /dev/nvidia0 ]


### PR DESCRIPTION
It cannot be relied on $XDG_SESSION_TYPE alone, so verify the $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY socket exists.

Fixes the issue raised in https://github.com/flathub/im.riot.Riot/commit/2061305f3a847399d070b430acc8d4e906c88641#commitcomment-101202103