### PR TITLE
fix: Add workaround to disable broken search

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -2,6 +2,11 @@
 
 FLAGS=''
 
+# Workaround for currently broken search, disabling it, without the need to manage to navigate to seshat settings.
+if [[ $DISABLE_ENCRYPTED_SEARCH == "true" ]]; then
+    find ${XDG_CONFIG_HOME} -type d -a -name EventStore -exec rm -r {} \&\& touch {} \;
+fi
+
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"


### PR DESCRIPTION
This patch intentionally breaks search and can be used to disable the Element Search indexing for users unable to navigate to the right settings page on time.

This is achieved by replacing the existing search index directory (`${XDG_CONFIG_HOME}/<Element Profile>/EventStore`) with a file, triggering EEXIST error and resulting in a failed initialisation. This can easily be fixed using the UI and as long as all messages are still available on the homeserver, no data is lost and the index can be rebuilt.

In order to use this workaround, either start the flatpak using `flatpak run --env=DISABLE_ENCRYPTED_SEARCH=true im.riot.Riot` or add the environment variable using flatseal. A one time treatment should be enough as long as you already have a profile with an EventStore directory.