### PR TITLE
Enable text-input-v1 support for Wayland IME under KWin/Weston/Hyprland

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -9,7 +9,7 @@ fi
 
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
-    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
+    FLAGS="$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
     if  [ -c /dev/nvidia0 ]
     then
         FLAGS="$FLAGS --disable-gpu-sandbox"


### PR DESCRIPTION
Chromium supports text-input-v1 under ozone wayland but requires the flag `--enable-wayland-ime` to enable it. KWin added support for this in https://invent.kde.org/plasma/kwin/-/merge_requests/3403 and Hyprland just landed support for this in https://github.com/hyprwm/Hyprland/pull/1778 as well.