### PR TITLE
Use static build instead of unpacking the deb

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -2,11 +2,6 @@
 
 FLAGS=''
 
-# Workaround for currently broken search, disabling it, without the need to manage to navigate to seshat settings.
-if [[ $DISABLE_ENCRYPTED_SEARCH == "true" ]]; then
-    find ${XDG_CONFIG_HOME} -type d -a -name EventStore -exec rm -r {} \&\& touch {} \;
-fi
-
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -5,8 +5,6 @@ runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: element
-rename-icon: element-desktop
-copy-icon: true
 separate-locales: false
 finish-args:
   # Version required to use the document-portal v4
@@ -53,61 +51,28 @@ cleanup:
   - /man
 modules:
   - shared-modules/libsecret/libsecret.json
-  - name: tcl
-    subdir: unix
-    build-options:
-      no-debuginfo: true
-    cleanup:
-      - '*'
-    sources:
-      - type: git
-        url: https://github.com/tcltk/tcl.git
-        tag: core-8-6-11
-        commit: 17b5b3e0201cdf92d3c125776e1b2dd453f225bd
-  - name: sqlcipher
-    rm-configure: true
-    config-opts:
-      - --enable-tempstore=yes
-      - --disable-tcl
-    build-options:
-      cflags: -DSQLITE_HAS_CODEC
-      ldflags: -lcrypto
-    sources:
-      - type: archive
-        url: https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.tar.gz
-        sha256: fccb37e440ada898902b294d02cde7af9e8706b185d77ed9f6f4d5b18b4c305f
-      - type: shell
-        commands:
-          - cp -p /usr/share/automake-*/config.{sub,guess} .
-      - type: script
-        dest-filename: autogen.sh
-        commands:
-          - AUTOMAKE="automake --foreign" autoreconf -vfi
   - name: riot
     buildsystem: simple
     build-commands:
-      - ar x element-desktop_*.deb
-      - rm element-desktop_*.deb
-      - tar xf data.tar.xz
-      - cp -r 'opt/Element' /app/Element
-      - mkdir -p /app/share/icons/hicolor
-      - cp -r usr/share/icons/hicolor/* /app/share/icons/hicolor
-      - chmod -R a-s,go+rX,go-w "/app/Element"
       - install element.sh /app/bin/element
       - install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop
       - install -Dm644 im.riot.Riot.metainfo.xml /app/share/metainfo/im.riot.Riot.metainfo.xml
+      - rm element.sh im.riot.Riot.desktop im.riot.Riot.metainfo.xml
+      - install -Dm644 resources/img/element.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
+      - mkdir /app/Element
+      - cp -r * /app/Element
+      - chmod -R a-s,go+rX,go-w "/app/Element"
     sources:
-      - type: file
+      - type: archive
         only-arches:
           - x86_64
-        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.11.30_amd64.deb
-        sha256: 71e69e4c5adcd1ff035d5b2f398e7f25448baa8bd26889030939bdc3c2873dbf
+        url: https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-1.11.31.tar.gz
+        sha256: 9fc46497a1b01b8040225ab87c8abc47b9de9bb65f2e8eafce546006e7669bb2
         x-checker-data:
-          type: debian-repo
-          package-name: element-desktop
-          root: https://packages.element.io/debian
-          dist: sid
-          component: main
+          type: html
+          url: https://packages.element.io/desktop/install/linux/glibc-x86-64/index.html
+          version-pattern: "element-desktop-([\\d\\.-]*).tar.gz"
+          url-template: "https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-$version.tar.gz"
       - type: file
         path: element.sh
       - type: file


### PR DESCRIPTION
~~It's unfortunately still crashing when using seshat for search in encrypted rooms :(
Next version of seshat should allow to build openssl statically too, let's see if it helps.~~

Search in encrypted rooms has been fixed !