### PR TITLE
Revert "Enable text-input-v1 support for Wayland IME under KWin/Weston/Hyprland"

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -9,7 +9,7 @@ fi
 
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
-    FLAGS="$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
+    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
     if  [ -c /dev/nvidia0 ]
     then
         FLAGS="$FLAGS --disable-gpu-sandbox"


### PR DESCRIPTION
Reverts flathub/im.riot.Riot#350

1.11.30 will probably be using electron24 which is based on chromium 112 which [crashes](https://bugs.chromium.org/p/chromium/issues/detail?id=1431532) with this flag.

Chromium has decided to break this so there's nothing much I can do...

Please merge when updating to 1.11.30