### PR TITLE
Drop `own-name=org.kde.*`

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -25,8 +25,6 @@ finish-args:
   # Required for notifications in various desktop environments
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Required for tray icons on KDE
-  - --own-name=org.kde.*
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver
   # Required for advanced input methods e.g. writing CJK languages
@@ -35,7 +33,7 @@ finish-args:
   - --filesystem=xdg-run/keyring
   # Required for experimental wayland support
   - --filesystem=xdg-run/pipewire-0
-  # For correct cursor scaling under Wayland 
+  # For correct cursor scaling under Wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 cleanup:
   - /include


### PR DESCRIPTION
Element 1.11.36 uses Electron 25.0.0 based on Chromium 114.0.5735.45 which includes the patch https://chromium.googlesource.com/chromium/src/+/9585757f9fad5af3b3a0c113b4aebd0101fe1abc

It no longer requires ownership access

The patch is included in Electron >=23

In my testing `org.kde.StatusNotifierWatcher` also seems to be not required any more. But please test it on KDE and GNOME.