### PR TITLE
Revert "Revert "Enable text-input-v1 support for Wayland IME under KWin/Weston/Hyprland""

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -4,7 +4,7 @@ FLAGS=''
 
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
-    FLAGS="$FLAGS --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
+    FLAGS="$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
     if  [ -c /dev/nvidia0 ]
     then
         FLAGS="$FLAGS --disable-gpu-sandbox"


### PR DESCRIPTION
Reverts flathub/im.riot.Riot#359

The actual bug has been fixed w/ https://chromium-review.googlesource.com/c/chromium/src/+/4423030 and has been fixed a long time ago. The reason I didn't submit this before is that I have been hitting https://github.com/flathub/im.riot.Riot/issues/381 regardless of whether `--enable-wayland-ime` is added. However https://github.com/flathub/im.riot.Riot/issues/381 doesn't seem to be reproducible w/ 1.11.41 which seems to be using electron26, and `--enable-wayland-ime` works just fine.