### PR TITLE
Use newer freedesktop platform 23.08

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -23,7 +23,6 @@ finish-args:
   # As a chat application, networking is required
   - --share=network
   # Required for notifications in various desktop environments
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -1,8 +1,8 @@
 app-id: im.riot.Riot
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: element
 separate-locales: false


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0). Brings some updated packages, but they probably won't affect Element.