### PR TITLE
README: change URL for Riot name change info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # im.riot.Riot
 
-This is a community-maintained [Flatpak](https://flatpak.org/) distribution of [Element Desktop](https://github.com/vector-im/element-desktop/), [formerly](https://element.io/previously-riot) called Riot.
+This is a community-maintained [Flatpak](https://flatpak.org/) distribution of [Element Desktop](https://github.com/vector-im/element-desktop/), [formerly](https://element.io/blog/the-world-is-changing/) called Riot.
 
 ## User-specified config.json
 


### PR DESCRIPTION
The previous link no longer works. This PR links it to the blog post announcing the change instead.