### PR TITLE
Make UnityLauncherAPI work

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,8 +34,6 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   # Required to use the UnityLauncherAPI
   - --talk-name=com.canonical.Unity
-  # Electron checks if it's running on Unity/KDE before using the UnityLauncherAPI. To make it work on other Desktops too, we need to pretend we are on KDE.
-  - --env=XDG_CURRENT_SESSION=KDE
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -32,6 +32,10 @@ finish-args:
   - --filesystem=xdg-run/pipewire-0
   # For correct cursor scaling under Wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  # Required to use the UnityLauncherAPI
+  - --talk-name=com.canonical.Unity
+  # Electron checks if it's running on Unity/KDE before using the UnityLauncherAPI. To make it work on other Desktops too, we need to pretend we are on KDE.
+  - --env=XDG_CURRENT_SESSION=KDE
 cleanup:
   - /include
   - /lib/pkgconfig
@@ -56,6 +60,7 @@ modules:
       - mkdir /app/Element
       - cp -r * /app/Element
       - chmod -R a-s,go+rX,go-w "/app/Element"
+      - patch-desktop-filename ${FLATPAK_DEST}/Element/resources/app.asar
     sources:
       - type: archive
         only-arches:


### PR DESCRIPTION
This makes the UnityLauncherAPI work. It allows Electron. It allows Element to show the number of unread messages in the Window Icon, on those Desktops that supports it. This is how it looks like on KDE:

![301615885-557855de-1002-4a13-a8ab-a8f4431a4d05](https://github.com/flathub/im.riot.Riot/assets/15185051/724e41a6-308b-4e25-890b-41614b843d16)

It is also supported by [Dash to Dock](https://micheleg.github.io/dash-to-dock/) and [Plank](https://launchpad.net/plank) and most likely also others. Unfortunately Electron [checks if it running on KDE or Unity](https://github.com/electron/electron/blob/fb88375ab4d2161dbf7e958a2a94c7c6d97dc84c/shell/browser/linux/unity_service.cc#L64) before using this API, so we need pretend we are on KDE to make it work on all Desktops.