### PR TITLE
Don't enable Wayland support by default

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -15,8 +15,6 @@ finish-args:
   # At least that's what the legends tell. it might be worth experimenting
   # with dropping this permission.
   - --share=ipc
-  # Required for experimental wayland support
-  - --socket=wayland
   # Required to provide Call functionality
   - --socket=pulseaudio
   - --device=all


### PR DESCRIPTION
It's not entirely stable yet. It might be best to let people opt in via Flatseal if they desire for now.

https://github.com/flathub/im.riot.Riot/issues/382#issuecomment-1933290992
https://github.com/element-hq/element-desktop/issues/768
https://github.com/element-hq/element-desktop/issues/873
https://github.com/element-hq/element-desktop/issues/1040