### PR TITLE
Add arm64 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/element.sh
+++ b/element.sh
@@ -2,6 +2,11 @@
 
 FLAGS=''
 
+# Workaround for currently broken search, disabling it, without the need to manage to navigate to seshat settings.
+if [[ $DISABLE_ENCRYPTED_SEARCH == "true" ]]; then
+    find ${XDG_CONFIG_HOME} -type d -a -name EventStore -exec rm -r {} \&\& touch {} \;
+fi
+
 if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
 then
     FLAGS="$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -47,7 +47,6 @@ cleanup:
   - /share/man
   - /man
 modules:
-  - shared-modules/libsecret/libsecret.json
   - name: tcl
     subdir: unix
     build-options:
@@ -95,14 +94,23 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.11.30_amd64.deb
-        sha256: 71e69e4c5adcd1ff035d5b2f398e7f25448baa8bd26889030939bdc3c2873dbf
+        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.11.59_amd64.deb
+        sha256: 1195c48e63ac4900cd8538a296dcfeb322cd6dd133358f1ee66699282e69056d
         x-checker-data:
-          type: debian-repo
-          package-name: element-desktop
-          root: https://packages.element.io/debian
-          dist: sid
-          component: main
+          type: html
+          url: https://packages.element.io/debian/pool/main/e/element-desktop/index.html
+          version-pattern: "element-desktop_([\\d\\.-]*)_amd64.deb"
+          url-template: "https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_${version}_amd64.deb"
+      - type: file
+        only-arches:
+          - aarch64
+        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.11.59_arm64.deb
+        sha256: 34c3c29712357a660d68f25d6b731330ce84b04411eb6122700c8c96c9e18ef0
+        x-checker-data:
+          type: html
+          url: https://packages.element.io/debian/pool/main/e/element-desktop/index.html
+          version-pattern: "element-desktop_([\\d\\.-]*)_arm64.deb"
+          url-template: "https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_${version}_arm64.deb"
       - type: file
         path: element.sh
       - type: file

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -5,6 +5,8 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: element
+rename-icon: element-desktop
+copy-icon: true
 separate-locales: false
 finish-args:
   # Version required to use the document-portal v4
@@ -45,28 +47,62 @@ cleanup:
   - /share/man
   - /man
 modules:
+  - shared-modules/libsecret/libsecret.json
+  - name: tcl
+    subdir: unix
+    build-options:
+      no-debuginfo: true
+    cleanup:
+      - '*'
+    sources:
+      - type: git
+        url: https://github.com/tcltk/tcl.git
+        tag: core-8-6-11
+        commit: 17b5b3e0201cdf92d3c125776e1b2dd453f225bd
+  - name: sqlcipher
+    rm-configure: true
+    config-opts:
+      - --enable-tempstore=yes
+      - --disable-tcl
+    build-options:
+      cflags: -DSQLITE_HAS_CODEC
+      ldflags: -lcrypto
+    sources:
+      - type: archive
+        url: https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.tar.gz
+        sha256: fccb37e440ada898902b294d02cde7af9e8706b185d77ed9f6f4d5b18b4c305f
+      - type: shell
+        commands:
+          - cp -p /usr/share/automake-*/config.{sub,guess} .
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - AUTOMAKE="automake --foreign" autoreconf -vfi
   - name: riot
     buildsystem: simple
     build-commands:
+      - ar x element-desktop_*.deb
+      - rm element-desktop_*.deb
+      - tar xf data.tar.xz
+      - cp -r 'opt/Element' /app/Element
+      - mkdir -p /app/share/icons/hicolor
+      - cp -r usr/share/icons/hicolor/* /app/share/icons/hicolor
+      - chmod -R a-s,go+rX,go-w "/app/Element"
       - install element.sh /app/bin/element
       - install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop
       - install -Dm644 im.riot.Riot.metainfo.xml /app/share/metainfo/im.riot.Riot.metainfo.xml
-      - rm element.sh im.riot.Riot.desktop im.riot.Riot.metainfo.xml
-      - install -Dm644 resources/img/element.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
-      - mkdir /app/Element
-      - cp -r * /app/Element
-      - chmod -R a-s,go+rX,go-w "/app/Element"
     sources:
-      - type: archive
+      - type: file
         only-arches:
           - x86_64
-        url: https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-1.11.59.tar.gz
-        sha256: e26f6df9d9743ac6df34ce1181f985afc8d4a52fe7884447bbfe282a9ca67792
+        url: https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_1.11.30_amd64.deb
+        sha256: 71e69e4c5adcd1ff035d5b2f398e7f25448baa8bd26889030939bdc3c2873dbf
         x-checker-data:
-          type: html
-          url: https://packages.element.io/desktop/install/linux/glibc-x86-64/index.html
-          version-pattern: element-desktop-([\d\.-]*).tar.gz
-          url-template: https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-$version.tar.gz
+          type: debian-repo
+          package-name: element-desktop
+          root: https://packages.element.io/debian
+          dist: sid
+          component: main
       - type: file
         path: element.sh
       - type: file


### PR DESCRIPTION
This is an updated #393, which was closed because there is no desire to switch back to unpacking debs just to add arm64 support. While I understand the motivation between not going back to unpacking debs, this would close #167, and the current build method is from binaries anyway (which Element doesn't seem to be interested in building for arm64), so neither are built from source.