### PR TITLE
Add branding colors

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -265,4 +265,8 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <update_contact>vrutkovs@redhat.com</update_contact>
+  <branding>
+    <color type="primary" scheme_preference="light">#71d7ae</color>
+    <color type="primary" scheme_preference="dark">#004832</color>
+  </branding>
 </component>


### PR DESCRIPTION
Picked two colors from https://github.com/element-hq/compound-design-tokens/blob/7f03b365cc6710cde6a02f43db116439eda76321/assets/web/css/cpd-theme-light-base.css#L234 and https://github.com/element-hq/compound-design-tokens/blob/7f03b365cc6710cde6a02f43db116439eda76321/assets/web/css/cpd-theme-dark-base.css#L234

![image](https://github.com/flathub/im.riot.Riot/assets/5943908/e5835fa4-1674-498e-9cd3-71b3cf17ad6a)

https://docs.flathub.org/banner-preview