### PR TITLE
feat: enable proxy via reading envrionment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ This is a community-maintained [Flatpak](https://flatpak.org/) distribution of [
 ## User-specified config.json
 
 Element Desktop's [instructions](https://github.com/vector-im/element-desktop/#user-specified-configjson) to use user-specified configuration settings do not apply. Instead, `config.json` must be created at `~/.var/app/im.riot.Riot/config/$NAME/config.json`, where `$NAME` is typically `Element`. The contents of the file are otherwise the same.
+
+## Networking proxy
+
+Overriding enviroment variables such as `all_proxy`, `http_proxy`, `https_proxy` can toggle proxy for Element Desktop. For example:
+
+```bash
+# enable proxy
+flatpak override --env=all_proxy=http://127.0.0.1:7890 im.riot.Riot
+
+# disable proxy overriding and use proxy settings from system (if current-shell env have related variables)
+flatpak override --unset-env=all_proxy im.riot.Riot
+
+# disable all proxy settings (Flatpak shell will inherit env from host shell sometimes)
+flatpak override --env=all_proxy="" --env=http_proxy="" --env=https_proxy="" im.riot.Riot
+```

--- a/element.sh
+++ b/element.sh
@@ -13,4 +13,13 @@ else
     FLAGS="$FLAGS --enable-features=WebRTCPipeWireCapturer"
 fi
 
+# to apply proxy from environment variable
+if [[ $all_proxy ]]; then
+    FLAGS="$FLAGS --proxy-server=$all_proxy"
+elif [[ $http_proxy ]]; then
+    FLAGS="$FLAGS --proxy-server=$http_proxy"
+elif [[ $https_proxy ]]; then
+    FLAGS="$FLAGS --proxy-server=$https_proxy"
+fi
+
 env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-im.riot.Riot}" zypak-wrapper /app/Element/element-desktop $FLAGS "$@"


### PR DESCRIPTION
Allow user to apply proxy by overriding proxy-related environment variables.

Related issue: #164 

Ref:

> Apparently, you can set the proxy by using a `--proxy-server` option on the command-line (e.g. `--proxy-server=socks5://127.0.0.1:9050`)

_Originally posted by @uhoreg in https://github.com/element-hq/element-desktop/issues/772#issuecomment-1513258947_