### PR TITLE
Enable wayland backend (once ready)

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,6 +34,8 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   # Required to use the UnityLauncherAPI
   - --talk-name=com.canonical.Unity
+  # Required for wayland/xorg auto switch
+  - --env=OZONE_PLATFORM=auto
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -35,7 +35,7 @@ finish-args:
   # Required to use the UnityLauncherAPI
   - --talk-name=com.canonical.Unity
   # Required for wayland/xorg auto switch
-  - --env=OZONE_PLATFORM=auto
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
The im.riot.Riot.yaml file does mention that the wayland support is [experimental](https://github.com/flathub/im.riot.Riot/blob/ba075c7821ca91e63b8a10ff67ec10911b22c867/im.riot.Riot.yaml#L19) but I think its ready to be enabled.

Please see:
[Heroic games launcher](https://github.com/flathub/io.github.shiftey.Desktop/pull/337)
[Github desktop](https://github.com/flathub/com.heroicgameslauncher.hgl/pull/171)
[Discord Canary](https://www.youtube.com/watch?v=SeeNm43jnn0)