### PR TITLE
feat: Evaluate WAYLAND_DISPLAY variable according to spec

### DIFF
--- a/element.sh
+++ b/element.sh
@@ -2,7 +2,15 @@
 
 FLAGS=''
 
-if [[ $XDG_SESSION_TYPE == "wayland" && -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]
+# Checking for absolute path in WAYLAND_DISPLAY variable.
+# As referenced in the description of the `wl_display_add_socket` function at https://wayland.freedesktop.org/docs/html/apc.html#id-1.11.2
+if [ "${WAYLAND_DISPLAY:0:1}" = "/" ]; then
+    WAYLAND_SOCKET_PATH="${WAYLAND_DISPLAY}"
+else
+    WAYLAND_SOCKET_PATH="$XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-wayland-0}"
+fi
+
+if [[ $XDG_SESSION_TYPE == "wayland" && -e "$WAYLAND_SOCKET_PATH" ]]
 then
     FLAGS="$FLAGS --enable-wayland-ime --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer"
     if  [ -c /dev/nvidia0 ]


### PR DESCRIPTION
This should resolve potential issues with more exotic distros and their take on wayland support in flatpak.

References:
https://github.com/flathub/im.riot.Riot/pull/494