### PR TITLE
appdata: Drop empty release information

### DIFF
--- a/im.riot.Riot.metainfo.xml
+++ b/im.riot.Riot.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>im.riot.Riot</id>
   <name>Element</name>
   <project_license>AGPL-3.0-only OR GPL-3.0-only</project_license>
@@ -32,96 +32,12 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.12.7" date="2025-12-16">
-      <description></description>
-    </release>
-    <release version="1.12.6" date="2025-12-03">
-      <description/>
-    </release>
-    <release version="1.12.4" date="2025-11-18">
-      <description/>
-    </release>
-    <release version="1.12.3" date="2025-11-04">
-      <description/>
-    </release>
-    <release version="1.12.2" date="2025-10-21">
-      <description/>
-    </release>
-    <release version="1.12.1" date="2025-10-07">
-      <description/>
-    </release>
-    <release version="1.12.0" date="2025-09-23">
-      <description/>
-    </release>
-    <release version="1.11.112" date="2025-09-16">
-      <description/>
-    </release>
-    <release version="1.11.111" date="2025-09-10">
-      <description/>
-    </release>
-    <release version="1.11.110" date="2025-08-27">
-      <description/>
-    </release>
-    <release version="1.11.109" date="2025-08-11">
-      <description/>
-    </release>
-    <release version="1.11.106" date="2025-07-15">
-      <description/>
-    </release>
-    <release version="1.11.105" date="2025-07-01">
-      <description/>
-    </release>
-    <release version="1.11.104" date="2025-06-17">
-      <description/>
-    </release>
-    <release version="1.11.103" date="2025-06-10">
-      <description/>
-    </release>
-    <release version="1.11.100" date="2025-05-06">
-      <description/>
-    </release>
-    <release version="1.11.99" date="2025-04-23">
-      <description/>
-    </release>
-    <release version="1.11.98" date="2025-04-22">
-      <description/>
-    </release>
-    <release version="1.11.97" date="2025-04-08">
-      <description/>
-    </release>
-    <release version="1.11.96" date="2025-03-25">
-      <description/>
-    </release>
-    <release version="1.11.95" date="2025-03-11">
-      <description/>
-    </release>
-    <release version="1.11.94" date="2025-02-27">
-      <description/>
-    </release>
-    <release version="1.11.93" date="2025-02-25">
-      <description/>
-    </release>
-    <release version="1.11.92" date="2025-02-11">
-      <description/>
-    </release>
-    <release version="1.11.91" date="2025-01-28">
-      <description/>
-    </release>
-    <release version="1.11.90" date="2025-01-14">
-      <description/>
-    </release>
-    <release version="1.11.89" date="2024-12-18">
-      <description/>
-    </release>
-    <release version="1.11.88" date="2024-12-17">
-      <description/>
-    </release>
-    <release version="1.11.87" date="2024-12-03">
-      <description/>
-    </release>
-    <release version="1.11.86" date="2024-11-19">
-      <description/>
-    </release>
+    <release version="1.12.7" date="2025-12-16"/>
+    <release version="1.12.6" date="2025-12-03"/>
+    <release version="1.12.4" date="2025-11-18"/>
+    <release version="1.12.3" date="2025-11-04"/>
+    <release version="1.12.2" date="2025-10-21"/>
+    <release version="1.12.1" date="2025-10-07"/>
     <release version="1.11.85" date="2024-11-12" urgency="high">
       <description/>
       <issues>
@@ -130,40 +46,10 @@
         <issue type="cve">CVE-2024-51749</issue>
       </issues>
     </release>
-    <release version="1.11.84" date="2024-11-05">
-      <description/>
-    </release>
-    <release version="1.11.83" date="2024-10-29">
-      <description/>
-    </release>
-    <release version="1.11.82" date="2024-10-22">
-      <description/>
-    </release>
     <release version="1.11.81" date="2024-10-15" urgency="high">
        <issues>
          <issue type="cve">CVE-2024-47771</issue>
        </issues>
-      <description/>
-    </release>
-    <release version="1.11.80" date="2024-10-08">
-      <description/>
-    </release>
-    <release version="1.11.79" date="2024-10-01">
-      <description/>
-    </release>
-    <release version="1.11.78" date="2024-09-24">
-      <description/>
-    </release>
-    <release version="1.11.77" date="2024-09-10">
-      <description/>
-    </release>
-    <release version="1.11.76" date="2024-08-27">
-      <description/>
-    </release>
-    <release version="1.11.75" date="2024-08-20">
-      <description/>
-    </release>
-    <release version="1.11.74" date="2024-08-13">
       <description/>
     </release>
     <release version="1.11.73" date="2024-08-06" urgency="high">
@@ -171,80 +57,11 @@
          <issue type="cve">CVE-2024-42347</issue>
        </issues>
     </release>
-    <release version="1.11.72" date="2024-07-30">
-      <description/>
-    </release>
-    <release version="1.11.71" date="2024-07-16">
-      <description/>
-    </release>
-    <release version="1.11.70" date="2024-07-08">
-      <description/>
-    </release>
-    <release version="1.11.69" date="2024-06-18">
-      <description/>
-    </release>
-    <release version="1.11.68" date="2024-06-04">
-      <description/>
-    </release>
-    <release version="1.11.67" date="2024-05-22">
-      <description/>
-    </release>
-    <release version="1.11.66" date="2024-05-07"/>
-    <release version="1.11.65" date="2024-04-23"/>
-    <release version="1.11.64" date="2024-04-09"/>
-    <release version="1.11.63" date="2024-03-28"/>
-    <release version="1.11.62" date="2024-03-26"/>
-    <release version="1.11.61" date="2024-03-14"/>
-    <release version="1.11.60" date="2024-03-12"/>
-    <release version="1.11.59" date="2024-02-27"/>
-    <release version="1.11.58" date="2024-02-13"/>
-    <release version="1.11.57" date="2024-01-31"/>
-    <release version="1.11.55" date="2024-01-19"/>
-    <release version="1.11.54" date="2024-01-16"/>
-    <release version="1.11.53" date="2024-01-04"/>
-    <release version="1.11.52" date="2023-12-19"/>
-    <release version="1.11.51" date="2023-12-05"/>
-    <release version="1.11.50" date="2023-11-21"/>
-    <release version="1.11.49" date="2023-11-13"/>
-    <release version="1.11.48" date="2023-11-07"/>
-    <release version="1.11.47" date="2023-10-24"/>
-    <release version="1.11.46" date="2023-10-10"/>
     <release version="1.11.45" date="2023-09-29" urgency="high">
       <issues>
         <issue type="cve">CVE-2023-5217</issue>
       </issues>
     </release>
-    <release version="1.11.43" date="2023-09-15"/>
-    <release version="1.11.41" date="2023-09-12"/>
-    <release version="1.11.40" date="2023-08-29"/>
-    <release version="1.11.39" date="2023-08-15"/>
-    <release version="1.11.38" date="2023-08-04"/>
-    <release version="1.11.37" date="2023-08-01"/>
-    <release version="1.11.36" date="2023-07-18"/>
-    <release version="1.11.35" date="2023-07-04"/>
-    <release version="1.11.34" date="2023-06-20"/>
-    <release version="1.11.33" date="2023-06-09"/>
-    <release version="1.11.32" date="2023-06-06"/>
-    <release version="1.11.31" date="2023-05-11"/>
-    <release version="1.11.30" date="2023-04-25"/>
-    <release version="1.11.29" date="2023-04-11"/>
-    <release version="1.11.28" date="2023-03-31"/>
-    <release version="1.11.27" date="2023-03-31"/>
-    <release version="1.11.26" date="2023-03-28"/>
-    <release version="1.11.25" date="2023-03-15"/>
-    <release version="1.11.24" date="2023-02-28"/>
-    <release version="1.11.23" date="2023-02-14"/>
-    <release version="1.11.22" date="2023-01-31"/>
-    <release version="1.11.20" date="2023-01-20"/>
-    <release version="1.11.18" date="2023-01-18"/>
-    <release version="1.11.17" date="2022-12-21"/>
-    <release version="1.11.16" date="2022-12-06"/>
-    <release version="1.11.15" date="2022-11-22"/>
-    <release version="1.11.14" date="2022-11-08"/>
-    <release version="1.11.13" date="2022-11-01"/>
-    <release version="1.11.12" date="2022-10-26"/>
-    <release version="1.11.11" date="2022-10-25"/>
-    <release version="1.11.10" date="2022-10-11"/>
     <release version="1.11.8" date="2022-09-28" urgency="critical">
       <description>
         <p>Fixes various security vulnerabilities.</p>
@@ -257,30 +74,6 @@
         <issue type="cve">CVE-2022-39236</issue>
       </issues>
     </release>
-    <release version="1.11.5" date="2022-09-13"/>
-    <release version="1.11.4-1" date="2022-08-31"/>
-    <release version="1.11.4" date="2022-08-31"/>
-    <release version="1.11.3" date="2022-08-16"/>
-    <release version="1.11.2" date="2022-08-03"/>
-    <release version="1.11.1" date="2022-07-26"/>
-    <release version="1.11.0" date="2022-07-05"/>
-    <release version="1.10.15" date="2022-06-14"/>
-    <release version="1.10.14" date="2022-06-07"/>
-    <release version="1.10.13" date="2022-05-24"/>
-    <release version="1.10.12" date="2022-05-10"/>
-    <release version="1.10.11" date="2022-04-26"/>
-    <release version="1.10.10" date="2022-04-14"/>
-    <release version="1.10.9" date="2022-04-12"/>
-    <release version="1.10.8" date="2022-03-28"/>
-    <release version="1.10.7" date="2022-03-15"/>
-    <release version="1.10.6" date="2022-03-01"/>
-    <release version="1.10.5" date="2022-02-28"/>
-    <release version="1.10.4" date="2022-02-17"/>
-    <release version="1.10.3" date="2022-02-14"/>
-    <release version="1.10.1" date="2022-02-01"/>
-    <release version="1.10.0" date="2022-01-31"/>
-    <release version="1.9.9" date="2022-01-17"/>
-    <release version="1.9.8" date="2021-12-20"/>
     <release version="1.9.7" date="2021-12-13" urgency="high">
       <description>
         <p>Fix for buffer overflow in libolm and matrix-js-sdk</p>
@@ -290,140 +83,11 @@
         <issue type="cve">CVE-2021-44538</issue>
       </issues>
     </release>
-    <release version="1.9.6" date="2021-12-06"/>
-    <release version="1.9.5" date="2021-11-22"/>
-    <release version="1.9.4" date="2021-11-08"/>
-    <release version="1.9.3" date="2021-10-25"/>
-    <release version="1.9.2" date="2021-10-12"/>
-    <release version="1.9.1" date="2021-10-11"/>
-    <release version="1.9.0" date="2021-09-27"/>
-    <release version="1.8.5" date="2021-09-14"/>
-    <release version="1.8.4" date="2021-09-13"/>
-    <release version="1.8.2" date="2021-08-31"/>
-    <release version="1.8.1" date="2021-08-17"/>
-    <release version="1.8.0" date="2021-08-16"/>
-    <release version="1.7.34" date="2021-08-02"/>
-    <release version="1.7.33" date="2021-07-19"/>
-    <release version="1.7.32" date="2021-07-05"/>
-    <release version="1.7.31" date="2021-06-21"/>
-    <release version="1.7.30" date="2021-06-07"/>
-    <release version="1.7.29" date="2021-05-24"/>
-    <release version="1.7.28" date="2021-05-17"/>
-    <release version="1.7.27" date="2021-05-10"/>
-    <release version="1.7.26" date="2021-04-27"/>
-    <release version="1.7.25" date="2021-04-12"/>
-    <release version="1.7.24" date="2021-03-29"/>
-    <release version="1.7.23" date="2021-03-15"/>
-    <release version="1.7.22" date="2021-03-01"/>
-    <release version="1.7.21" date="2021-02-16"/>
-    <release version="1.7.20" date="2021-02-04"/>
-    <release version="1.7.18" date="2021-01-26"/>
-    <release version="1.7.17" date="2021-01-18"/>
-    <release version="1.7.16" date="2020-12-21"/>
-    <release version="1.7.15" date="2020-12-07"/>
-    <release version="1.7.14" date="2020-11-23"/>
-    <release version="1.7.13" date="2020-11-09"/>
-    <release version="1.7.12" date="2020-10-28"/>
-    <release version="1.7.11" date="2020-10-27"/>
-    <release version="1.7.10" date="2020-10-20"/>
-    <release version="1.7.9" date="2020-10-12"/>
-    <release version="1.7.8" date="2020-09-29"/>
-    <release version="1.7.7" date="2020-09-14"/>
-    <release version="1.7.5" date="2020-09-01"/>
-    <release version="1.7.4" date="2020-08-17"/>
-    <release version="1.7.3" date="2020-08-05"/>
-    <release version="1.7.2" date="2020-07-27"/>
-    <release version="1.7.1" date="2020-07-16"/>
-    <release version="1.7.0" date="2020-07-15"/>
-    <release version="1.6.8" date="2020-07-03"/>
-    <release version="1.6.7" date="2020-06-29"/>
-    <release version="1.6.6" date="2020-06-23"/>
-    <release version="1.6.5" date="2020-06-16"/>
-    <release version="1.6.4" date="2020-06-05"/>
-    <release version="1.6.3" date="2020-06-04"/>
-    <release version="1.6.2" date="2020-05-22"/>
-    <release version="1.6.1" date="2020-05-19"/>
-    <release version="1.6.0" date="2020-05-05"/>
-    <release version="1.5.15" date="2020-04-01"/>
-    <release version="1.5.14" date="2020-03-30"/>
-    <release version="1.5.13" date="2020-03-17"/>
-    <release version="1.5.12" date="2020-03-04"/>
-    <release version="1.5.10" date="2020-02-19"/>
-    <release version="1.5.8" date="2020-01-27"/>
-    <release version="1.5.7" date="2020-01-13"/>
-    <release version="1.5.6" date="2019-12-09"/>
-    <release version="1.5.5" date="2019-11-27"/>
-    <release version="1.5.4" date="2019-11-25"/>
-    <release version="1.5.3" date="2019-11-06"/>
-    <release version="1.5.1" date="2019-11-04"/>
-    <release version="1.5.0" date="2019-10-18"/>
-    <release version="1.4.2" date="2019-10-04"/>
-    <release version="1.4.1" date="2019-10-01"/>
-    <release version="1.4.0" date="2019-09-27"/>
-    <release version="1.3.5" date="2019-09-16"/>
-    <release version="1.3.0" date="2019-07-19"/>
-    <release version="1.2.4" date="2019-07-11"/>
-    <release version="1.2.3" date="2019-07-08"/>
-    <release version="1.2.2" date="2019-06-19"/>
-    <release version="1.2.1" date="2019-05-31"/>
-    <release version="1.2.0" date="2019-05-29"/>
-    <release version="1.1.2" date="2019-05-16"/>
-    <release version="1.1.1" date="2019-05-14"/>
-    <release version="1.1.0" date="2019-05-07"/>
-    <release version="1.0.7" date="2019-04-08"/>
-    <release version="1.0.6" date="2019-04-01"/>
-    <release version="1.0.5" date="2019-03-21"/>
-    <release version="1.0.4" date="2019-03-19"/>
-    <release version="1.0.3" date="2019-03-11"/>
-    <release version="1.0.1" date="2019-02-15"/>
-    <release version="0.17.9" date="2019-01-22"/>
-    <release version="0.17.8" date="2019-01-10"/>
-    <release version="0.17.6" date="2018-11-19"/>
-    <release version="0.17.3" date="2018-10-29"/>
-    <release version="0.17.0" date="2018-10-16"/>
-    <release version="0.16.5" date="2018-10-01"/>
-    <release version="0.16.4" date="2018-09-10"/>
-    <release version="0.16.3" date="2018-09-03"/>
-    <release version="0.16.2" date="2018-08-23"/>
-    <release version="0.16.0" date="2018-07-30"/>
-    <release version="0.15.7" date="2018-07-09"/>
-    <release version="0.15.6" date="2018-06-29"/>
-    <release version="0.15.4" date="2018-05-25"/>
-    <release version="0.15.3" date="2018-05-18"/>
-    <release version="0.14.1" date="2018-04-12"/>
-    <release version="0.14.0" date="2018-04-11"/>
-    <release version="0.13.5" date="2018-02-09"/>
-    <release version="0.13.4" date="2018-01-03"/>
-    <release version="0.13.0" date="2017-11-15"/>
   </releases>
   <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
     <content_attribute id="social-audio">intense</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
     <content_attribute id="social-contacts">intense</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <update_contact>vrutkovs@redhat.com</update_contact>
   <branding>


### PR DESCRIPTION
- Instead of an empty description, use "/> instead.
- Drop empty release information that provides no real value
- Use desktop-application component type
- Drop redundant OARS ratings 

Actually, only the last 5 entries can be visible on GNOME Software and Bazaar; there is no need for all other release information.