### PR TITLE
Add talk-name for KDE wallet daemon

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -26,6 +26,8 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # Required to allow screensaver/idle inhibition such as during video calls
   - --talk-name=org.freedesktop.ScreenSaver
+  # Required to store secret keys for message encryption on KDE
+  - --talk-name=org.kde.kwalletd6
   # Required to store access tokens (persistent logins)
   - --filesystem=xdg-run/keyring
   # Required for experimental wayland support


### PR DESCRIPTION
Added support for KDE wallet daemon in Riot configuration.

partial fix for: https://github.com/flathub/im.riot.Riot/issues/528