### PR TITLE
Add read-only access to home directory for drag and drop

### DIFF
--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,8 +34,9 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   # Required to use the UnityLauncherAPI
   - --talk-name=com.canonical.Unity
-  # Read-only access to the home directory to allow loading of user images
+  # Read-only access to the home directory and to secondary drives to allow loading of user images
   - --filesystem=home:ro
+  - --filesystem=/mnt:ro
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/im.riot.Riot.yaml
+++ b/im.riot.Riot.yaml
@@ -34,6 +34,8 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   # Required to use the UnityLauncherAPI
   - --talk-name=com.canonical.Unity
+  # Read-only access to the home directory to allow loading of user images
+  - --filesystem=home:ro
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
By default, you can't drag and drop images, nor can you copy and paste steam screenshots. A quick bandaid solution I found was granting read only permissions to the home directory